### PR TITLE
Update the presence of the bot.

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,12 +10,12 @@ import DatabaseControl
 
 async def status_task():
   while True:
-    await client.change_presence(status=discord.Status.online, activity=discord.Activity(type=discord.ActivityType.listening, name="the return of JDBot"))
-    await asyncio.sleep(40)
-    await client.change_presence(status=discord.Status.online, activity=discord.Activity(type=discord.ActivityType.watching, name=f"{len(client.guilds)} servers | {len(client.users)} users"))
-    await asyncio.sleep(40)
-    await client.change_presence(status=discord.Status.online, activity=discord.Activity(type=discord.ActivityType.watching, name="the new updates coming soon..."))
-    await asyncio.sleep(40)
+    await client.change_presence(status=discord.Status.idle, activity=discord.Activity(type=discord.ActivityType.listening, name="the return of JDBot"))
+    await asyncio.sleep(10)
+    await client.change_presence(status=discord.Status.idle, activity=discord.Activity(type=discord.ActivityType.watching, name=f"{len(client.guilds)} servers | {len(client.users)} users"))
+    await asyncio.sleep(10)
+    await client.change_presence(status=discord.Status.idle, activity=discord.Activity(type=discord.ActivityType.watching, name="the new updates coming soon..."))
+    await asyncio.sleep(10)
 
 async def startup():
   await client.wait_until_ready()


### PR DESCRIPTION
The status should change more frequently because 40 seconds is way too long.
Idle status will match the bot's yellow pfp