### PR TITLE
[Paginator] Fix: Go back to original set style

### DIFF
--- a/utils/views.py
+++ b/utils/views.py
@@ -268,7 +268,8 @@ class Paginator(View):
             if not button.disabled:
                 button.style = ButtonStyle.green
             elif button.disabled:
-                button.style = ButtonStyle.secondary
+                key = button.custom_id.split("_")[0].upper()  # type: ignore
+                button.style = self._buttons[key].style
 
     @property
     def current_page(self) -> int:


### PR DESCRIPTION
Instead of hardcoding the style to go back to secondary, it goes to the style that was set in the buttons dict.